### PR TITLE
v0.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(project_prefix bave)
-project(${project_prefix} VERSION 0.4.0)
+project(${project_prefix} VERSION 0.4.1)
 
 set(is_root_project FALSE)
 

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.4.1
+
+- Fixed bave::Rgba::to_hex_str(). Previously it would skip leading zeroes for each byte.
+- Add some convenience functions on bave::EnumFlags.
+- Linearize vertex RGBA in bave::Geometry.
+- Preload font atlas for default bave::TextHeight.
+
 ## v0.4
 
 ### Features

--- a/lib/include/bave/core/enum_flags.hpp
+++ b/lib/include/bave/core/enum_flags.hpp
@@ -11,20 +11,32 @@ class EnumFlags : public std::bitset<Size> {
 
 	/// \brief Constructor taking multiple flags.
 	/// \param to_set flags to set.
+	/// \pre e must be non-negative and less than Size.
 	template <std::same_as<E>... T>
-	EnumFlags(T const... to_set) {
+	/*implicit*/ EnumFlags(T const... to_set) {
 		(this->set(to_set), ...);
 	}
 
 	/// \brief Test if a flag is set.
 	/// \param e Flag to test for.
 	/// \returns true if set.
+	/// \pre e must be non-negative and less than Size.
 	[[nodiscard]] auto test(E const e) const -> bool { return std::bitset<Size>::test(static_cast<std::size_t>(e)); }
+	/// \brief Test if any of given flags is set.
+	/// \param flags Flags to test for.
+	/// \returns true if any bit in flags is set.
+	[[nodiscard]] auto test_any(EnumFlags const& flags) const -> bool { return (flags & *this).any(); }
+	/// \brief Test if all of given flags are set.
+	/// \param flags Flags to test for.
+	/// \returns true if all bits in flags are set.
+	[[nodiscard]] auto test_all(EnumFlags const& flags) const -> bool { return (flags & *this) == flags; }
 	/// \brief Set a flag.
 	/// \param e Flag to set.
+	/// \pre e must be non-negative and less than Size.
 	void set(E const e) { std::bitset<Size>::set(static_cast<std::size_t>(e)); }
 	/// \brief Reset a flag.
 	/// \param e Flag to reset.
+	/// \pre e must be non-negative and less than Size.
 	void reset(E const e) { std::bitset<Size>::reset(static_cast<std::size_t>(e)); }
 
 	[[nodiscard]] auto operator[](E const e) -> decltype(auto) { return std::bitset<Size>::operator[](static_cast<std::size_t>(e)); }

--- a/lib/include/bave/font/font.hpp
+++ b/lib/include/bave/font/font.hpp
@@ -26,6 +26,11 @@ class Font {
 	/// \returns true on success.
 	auto load_from_bytes(std::vector<std::byte> file_bytes, float scale = scale_v) -> bool;
 
+	/// \brief Create font atlas for a specific text height.
+	/// \param height TextHeight to create atlas for.
+	/// \returns true if successful.
+	auto create_font_atlas(TextHeight height) -> bool;
+
 	[[nodiscard]] auto glyph_for(TextHeight height, Codepoint codepoint) -> Glyph;
 	[[nodiscard]] auto get_texture(TextHeight height) -> std::shared_ptr<Texture const>;
 

--- a/lib/include/bave/graphics/shader.hpp
+++ b/lib/include/bave/graphics/shader.hpp
@@ -24,6 +24,10 @@ class Shader {
 	auto write_ubo(void const* data, vk::DeviceSize size) -> bool;
 	auto write_ssbo(void const* data, vk::DeviceSize size) -> bool;
 
+	/// \brief Set the render view.
+	/// \param render_view View to set.
+	void set_render_view(RenderView const& render_view);
+
 	/// \brief Draw intsances of a primitive.
 	/// \param primitive Primitive to draw.
 	/// \param instances Instances to draw.

--- a/lib/include/bave/input/key_state.hpp
+++ b/lib/include/bave/input/key_state.hpp
@@ -29,8 +29,8 @@ struct KeyState {
 	/// \returns true if all keys have been pressed but not yet released.
 	/// \pre key must be non-negative and less than Key::eCOUNT_.
 	template <std::same_as<Key>... Ks>
-	[[nodiscard]] auto all_pressed(Ks const... key) const -> bool {
-		return held_keys.test_all(EnumFlags<Key>{key...});
+	[[nodiscard]] auto all_pressed(Ks const... keys) const -> bool {
+		return held_keys.test_all(EnumFlags<Key>{keys...});
 	}
 };
 } // namespace bave

--- a/lib/include/bave/input/key_state.hpp
+++ b/lib/include/bave/input/key_state.hpp
@@ -14,5 +14,23 @@ struct KeyState {
 	/// \returns true if key has been pressed but not yet released.
 	/// \pre key must be non-negative and less than Key::eCOUNT_.
 	[[nodiscard]] auto is_pressed(Key const key) const -> bool { return held_keys.test(key); }
+
+	/// \brief Check if any given key is pressed (held down).
+	/// \param keys The keys to check for.
+	/// \returns true if any key in keys has been pressed but not yet released.
+	/// \pre keys must be non-negative and less than Key::eCOUNT_.
+	template <std::same_as<Key>... Ks>
+	[[nodiscard]] auto any_pressed(Ks const... keys) const -> bool {
+		return held_keys.test_any(EnumFlags<Key>{keys...});
+	}
+
+	/// \brief Check if all given keys are pressed (held down).
+	/// \param keys The keys to check for.
+	/// \returns true if all keys have been pressed but not yet released.
+	/// \pre key must be non-negative and less than Key::eCOUNT_.
+	template <std::same_as<Key>... Ks>
+	[[nodiscard]] auto all_pressed(Ks const... key) const -> bool {
+		return held_keys.test_all(EnumFlags<Key>{key...});
+	}
 };
 } // namespace bave

--- a/lib/include/bave/loader.hpp
+++ b/lib/include/bave/loader.hpp
@@ -64,8 +64,9 @@ class Loader {
 	[[nodiscard]] auto load_texture_atlas(std::string_view uri, bool mip_map = false) const -> std::shared_ptr<TextureAtlas>;
 	/// \brief Try to load a Font.
 	/// \param uri URI to load from.
+	/// \param preload List of TextHeights to preload glyph atlases for.
 	/// \returns Font on success, nullptr on failure.
-	[[nodiscard]] auto load_font(std::string_view uri) const -> std::shared_ptr<Font>;
+	[[nodiscard]] auto load_font(std::string_view uri, std::span<TextHeight const> preload = {}) const -> std::shared_ptr<Font>;
 	/// \brief Try to load an AudioClip.
 	/// \param uri URI to load from.
 	/// \returns AudioClip on success, nullptr on failure.

--- a/lib/platform/desktop/desktop_app.cpp
+++ b/lib/platform/desktop/desktop_app.cpp
@@ -77,8 +77,8 @@ class FileLogger {
 	fs::path m_path{};
 	std::mutex m_mutex{};
 	std::string m_buffer{};
-	std::thread m_thread{};
 	std::atomic<bool> m_stop{};
+	std::thread m_thread{};
 };
 
 auto g_file_logger = std::unique_ptr<FileLogger>{}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/lib/src/font/font.cpp
+++ b/lib/src/font/font.cpp
@@ -14,6 +14,8 @@ auto Font::load_from_bytes(std::vector<std::byte> file_bytes, float scale) -> bo
 	return true;
 }
 
+auto Font::create_font_atlas(TextHeight const height) -> bool { return get_font_atlas(height) != nullptr; }
+
 auto Font::glyph_for(TextHeight height, Codepoint codepoint) -> Glyph {
 	if (auto const* atlas = get_font_atlas(height)) {
 		auto ret = atlas->glyph_for(codepoint);

--- a/lib/src/font/font.cpp
+++ b/lib/src/font/font.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 
 namespace bave {
-Font::Font(NotNull<RenderDevice*> render_device) : m_render_device(render_device) {}
+Font::Font(NotNull<RenderDevice*> render_device) : m_render_device(render_device) { create_font_atlas(TextHeight::eDefault); }
 
 auto Font::load_from_bytes(std::vector<std::byte> file_bytes, float scale) -> bool {
 	auto slot_factory = m_render_device->get_font_library().load(std::move(file_bytes));

--- a/lib/src/graphics/geometry.cpp
+++ b/lib/src/graphics/geometry.cpp
@@ -69,14 +69,12 @@ struct QuadWriter {
 			0, 1, 2, 3, 0,
 		};
 		out.append(vertices, indices);
-		// TODO: fixup
-		// out.topology = Topology::eLineStrip;
 	}
 
 	[[nodiscard]] static auto make_vertices(Quad const& quad) -> std::array<Vertex, 4> {
 		auto const half_size = 0.5f * quad.size;
 		auto const& o = quad.origin;
-		auto const rgba = quad.rgba.to_vec4();
+		auto const rgba = Rgba::to_linear(quad.rgba.to_vec4());
 		return std::array{
 			Vertex{{o.x - half_size.x, o.y + half_size.y}, quad.uv.top_left(), rgba},
 			Vertex{{o.x + half_size.x, o.y + half_size.y}, quad.uv.top_right(), rgba},
@@ -285,7 +283,7 @@ auto VertexArray::append(Circle const& circle) -> VertexArray& {
 	auto const resolution = circle.resolution;
 	auto const sector = Sector{
 		.origin = circle.origin,
-		.rgba = circle.rgba.to_vec4(),
+		.rgba = Rgba::to_linear(circle.rgba.to_vec4()),
 		.radius = 0.5f * circle.diameter,
 		.arc = {.finish = finish},
 		.step = Degrees{finish / static_cast<float>(resolution)},

--- a/lib/src/graphics/rgba.cpp
+++ b/lib/src/graphics/rgba.cpp
@@ -31,5 +31,5 @@ auto Rgba::from(std::string_view hex) -> Rgba {
 	return out;
 }
 
-auto Rgba::to_hex_str() const -> std::string { return fmt::format("#{:x}{:x}{:x}{:x}", channels.x, channels.y, channels.z, channels.w); }
+auto Rgba::to_hex_str() const -> std::string { return fmt::format("#{:02x}{:02x}{:02x}{:02x}", channels.x, channels.y, channels.z, channels.w); }
 } // namespace bave

--- a/lib/src/graphics/shader.cpp
+++ b/lib/src/graphics/shader.cpp
@@ -159,6 +159,8 @@ auto Shader::write_ssbo(void const* data, vk::DeviceSize const size) -> bool {
 	return true;
 }
 
+void Shader::set_render_view(RenderView const& render_view) { m_renderer->get_render_device().render_view = render_view; }
+
 void Shader::draw(RenderPrimitive const& primitive, std::span<RenderInstance::Baked const> instances) {
 	auto const command_buffer = m_renderer->get_command_buffer();
 	if (!command_buffer || primitive.bytes.empty() || instances.empty()) { return; }

--- a/lib/src/loader.cpp
+++ b/lib/src/loader.cpp
@@ -125,7 +125,7 @@ auto Loader::load_texture_atlas(std::string_view uri, bool mip_map) const -> std
 	return ret;
 }
 
-auto Loader::load_font(std::string_view const uri) const -> std::shared_ptr<Font> {
+auto Loader::load_font(std::string_view const uri, std::span<TextHeight const> preload) const -> std::shared_ptr<Font> {
 	auto const bytes = load_bytes(uri);
 	if (bytes.empty()) { return {}; }
 
@@ -134,6 +134,8 @@ auto Loader::load_font(std::string_view const uri) const -> std::shared_ptr<Font
 		m_log.warn("failed to load Font: '{}'", uri);
 		return {};
 	}
+
+	for (auto const height : preload) { [[maybe_unused]] auto const glyph = ret->glyph_for(height, {}); }
 
 	m_log.info("loaded Font: '{}'", uri);
 	return ret;


### PR DESCRIPTION
- Fix `Rgba::to_hex_str()`.
- Add some convenience functions.
- Linearize vertex RGBA in `Geometry`.
- Preload font atlas for default `TextHeight`.
