### PR TITLE
v0.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(project_prefix bave)
-project(${project_prefix} VERSION 0.4.2)
+project(${project_prefix} VERSION 0.4.3)
 
 set(is_root_project FALSE)
 

--- a/example/android/app/src/main/cpp/main.cpp
+++ b/example/android/app/src/main/cpp/main.cpp
@@ -6,7 +6,7 @@ extern "C" {
 void android_main(android_app* andr_app) {
 	// we will use bave::AndroidApp.
 	// create the App instance.
-	auto app = bave::AndroidApp{*andr_app};
+	auto app = bave::AndroidApp{*andr_app, vk::SampleCountFlagBits::e4};
 	// setup the entry point (Flappy).
 	app.set_bootloader([](bave::App& app) { return std::make_unique<Flappy>(app); });
 	// run App and return its exit code.

--- a/example/desktop/main.cpp
+++ b/example/desktop/main.cpp
@@ -9,6 +9,7 @@ auto main(int argc, char** argv) -> int {
 		.args = bave::make_args(argc, argv),
 		.title = "BaveExample",
 		.mode = bave::Windowed{.extent = {720, 1280}},
+		.msaa = vk::SampleCountFlagBits::e4,
 		.assets_patterns = "assets,example/assets",
 	};
 

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -5,6 +5,7 @@
 ### v0.4.3
 
 - Added bave::to_uv_rect() and bave::RenderView::to_n_scissor.
+- Fixed potential overflow in the general constructor of bave::FixedString.
 
 ### v0.4.2
 

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## v0.4
 
+### v0.4.3
+
+- Added bave::to_uv_rect() and bave::RenderView::to_n_scissor.
+
 ### v0.4.2
 
 - Fixed app shutdown/restart flow on Android.

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -7,6 +7,7 @@
 - Added bave::to_uv_rect() and bave::RenderView::to_n_scissor.
 - Added MSAA (multi sampled anti aliasing) support.
 - Fixed potential overflow in the general constructor of bave::FixedString.
+- Made bave::DesktopApp and bave::AndroidApp inherit privately from bave::App. This tightens the API available to either platform's main: they can only call bave::App::set_bootloader() and bave::App::run().
 
 ### v0.4.2
 

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -5,6 +5,7 @@
 ### v0.4.3
 
 - Added bave::to_uv_rect() and bave::RenderView::to_n_scissor.
+- Added MSAA (multi sampled anti aliasing) support.
 - Fixed potential overflow in the general constructor of bave::FixedString.
 
 ### v0.4.2

--- a/lib/include/bave/android_app.hpp
+++ b/lib/include/bave/android_app.hpp
@@ -16,7 +16,9 @@ class AInputEvent;
 namespace bave {
 class AndroidApp : public App, public detail::IWsi {
   public:
-	explicit AndroidApp(android_app& app, bool validation_layers = debug_v);
+	static constexpr auto msaa_v = vk::SampleCountFlagBits{vk::SampleCountFlagBits::e1};
+
+	explicit AndroidApp(android_app& app, vk::SampleCountFlagBits msaa = msaa_v, bool validation_layers = debug_v);
 
   private:
 	static auto self(Ptr<android_app> app) -> AndroidApp&;
@@ -58,6 +60,7 @@ class AndroidApp : public App, public detail::IWsi {
 	void handle_focus(bool gained);
 
 	android_app& m_app; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+	vk::SampleCountFlagBits m_msaa;
 	bool m_validation_layers;
 
 	std::unique_ptr<RenderDevice> m_render_device{};

--- a/lib/include/bave/android_app.hpp
+++ b/lib/include/bave/android_app.hpp
@@ -43,6 +43,7 @@ class AndroidApp : public App, public detail::IWsi {
 	[[nodiscard]] auto get_framebuffer_extent() const -> vk::Extent2D final;
 
 	auto do_set_window_size(glm::ivec2 /*size*/) -> bool final { return false; }
+	void do_wait_render_device_idle() final;
 
 	void setup_event_callbacks();
 

--- a/lib/include/bave/android_app.hpp
+++ b/lib/include/bave/android_app.hpp
@@ -14,11 +14,14 @@ class AInputEvent;
 }
 
 namespace bave {
-class AndroidApp : public App, public detail::IWsi {
+class AndroidApp : private App, private detail::IWsi {
   public:
 	static constexpr auto msaa_v = vk::SampleCountFlagBits{vk::SampleCountFlagBits::e1};
 
 	explicit AndroidApp(android_app& app, vk::SampleCountFlagBits msaa = msaa_v, bool validation_layers = debug_v);
+
+	using App::run;
+	using App::set_bootloader;
 
   private:
 	static auto self(Ptr<android_app> app) -> AndroidApp&;

--- a/lib/include/bave/app.hpp
+++ b/lib/include/bave/app.hpp
@@ -120,6 +120,9 @@ class App : public PolyPinned {
 
 	[[nodiscard]] auto get_features() const -> FeatureFlags;
 
+	/// \brief Wait until RenderDevice is idle.
+	void wait_render_device_idle() { do_wait_render_device_idle(); }
+
 	[[nodiscard]] auto get_data_store() const -> DataStore& { return *m_data_store; }
 	[[nodiscard]] auto get_render_device() const -> RenderDevice& { return do_get_render_device(); }
 	[[nodiscard]] auto get_renderer() const -> Renderer const& { return do_get_renderer(); }
@@ -178,6 +181,8 @@ class App : public PolyPinned {
 	virtual auto do_set_window_size(glm::ivec2 size) -> bool = 0;
 	virtual auto do_set_title(CString /*title*/) -> bool { return false; }
 	virtual auto do_set_window_icon(std::span<BitmapView const> /*bitmaps*/) -> bool { return false; }
+
+	virtual void do_wait_render_device_idle() = 0;
 
 	void pre_tick();
 

--- a/lib/include/bave/core/fixed_string.hpp
+++ b/lib/include/bave/core/fixed_string.hpp
@@ -22,7 +22,7 @@ class FixedString {
 	template <std::convertible_to<std::string_view> T>
 	FixedString(T const& t) {
 		auto const str = std::string_view{t};
-		m_size = str.size();
+		m_size = std::min(Capacity, str.size());
 		std::memcpy(m_buffer.data(), str.data(), m_size);
 	}
 

--- a/lib/include/bave/desktop_app.hpp
+++ b/lib/include/bave/desktop_app.hpp
@@ -34,6 +34,7 @@ class DesktopApp : public App, public detail::IWsi {
 		CString title{"BaveApp"};
 		DisplayMode mode{Windowed{}};
 		std::function<Gpu(std::span<Gpu const>)> select_gpu{};
+		vk::SampleCountFlagBits msaa{vk::SampleCountFlagBits::e1};
 		std::string_view assets_patterns{"assets"};
 		bool validation_layers{debug_v};
 	};

--- a/lib/include/bave/desktop_app.hpp
+++ b/lib/include/bave/desktop_app.hpp
@@ -91,6 +91,8 @@ class DesktopApp : public App, public detail::IWsi {
 	auto do_set_title(CString title) -> bool final;
 	auto do_set_window_icon(std::span<BitmapView const> bitmaps) -> bool final;
 
+	void do_wait_render_device_idle() final;
+
 	void init_data_store();
 	void make_window();
 	void init_graphics();

--- a/lib/include/bave/desktop_app.hpp
+++ b/lib/include/bave/desktop_app.hpp
@@ -26,7 +26,7 @@ struct BorderlessFullscreen {};
 using DisplayMode = std::variant<Windowed, BorderlessFullscreen>;
 
 /// \brief Concrete App for desktop.
-class DesktopApp : public App, public detail::IWsi {
+class DesktopApp : private App, private detail::IWsi {
   public:
 	/// \brief Data needed during construction.
 	struct CreateInfo {
@@ -42,6 +42,9 @@ class DesktopApp : public App, public detail::IWsi {
 	/// \brief Constructor.
 	/// \param create_info CreateInfo for this instance.
 	explicit DesktopApp(CreateInfo create_info);
+
+	using App::run;
+	using App::set_bootloader;
 
   private:
 	struct LogFile {

--- a/lib/include/bave/graphics/detail/pipeline_cache.hpp
+++ b/lib/include/bave/graphics/detail/pipeline_cache.hpp
@@ -65,6 +65,7 @@ class PipelineCache {
 	ShaderCache m_shader_cache;
 	DescriptorCache m_descriptor_cache;
 	vk::RenderPass m_render_pass{};
+	vk::SampleCountFlagBits m_samples{};
 	std::unordered_map<Key, vk::UniquePipeline, Hasher> m_pipelines{};
 	std::vector<vk::UniqueDescriptorSetLayout> m_descriptor_set_layouts{};
 	std::vector<vk::DescriptorSetLayout> m_descriptor_set_layouts_view{};

--- a/lib/include/bave/graphics/detail/render_resource.hpp
+++ b/lib/include/bave/graphics/detail/render_resource.hpp
@@ -80,7 +80,6 @@ class RenderImage : public RenderResource {
 
 	void recreate(vk::Extent2D extent);
 	auto overwrite(BitmapView bitmap, glm::ivec2 top_left) -> bool;
-	void resize(vk::Extent2D extent);
 
 	[[nodiscard]] auto get_render_device() const -> RenderDevice& { return *m_render_device; }
 

--- a/lib/include/bave/graphics/detail/render_resource.hpp
+++ b/lib/include/bave/graphics/detail/render_resource.hpp
@@ -62,6 +62,7 @@ class RenderImage : public RenderResource {
 		vk::ImageUsageFlags usage{usage_v};
 		vk::ImageAspectFlagBits aspect{vk::ImageAspectFlagBits::eColor};
 		vk::ImageTiling tiling{vk::ImageTiling::eOptimal};
+		vk::ImageLayout layout{vk::ImageLayout::eShaderReadOnlyOptimal};
 		vk::SampleCountFlagBits samples{vk::SampleCountFlagBits::e1};
 		vk::ImageViewType view_type{vk::ImageViewType::e2D};
 		bool mip_map{true};
@@ -89,7 +90,7 @@ class RenderImage : public RenderResource {
 	[[nodiscard]] auto get_format() const -> vk::Format { return m_create_info.format; }
 	[[nodiscard]] auto get_image_view() const -> vk::ImageView { return *m_view; }
 	[[nodiscard]] auto get_view_type() const -> vk::ImageViewType { return m_create_info.view_type; }
-	[[nodiscard]] auto get_layout() const -> vk::ImageLayout { return m_layout; }
+	[[nodiscard]] auto get_layout() const -> vk::ImageLayout { return m_create_info.layout; }
 	[[nodiscard]] auto get_mip_levels() const -> std::uint32_t { return m_mip_levels; }
 
 	[[nodiscard]] auto get_create_info() const -> CreateInfo const& { return m_create_info; }
@@ -103,7 +104,6 @@ class RenderImage : public RenderResource {
 	ScopedResource<vk::Image, Deleter> m_image{};
 	vk::Extent2D m_extent{};
 	vk::UniqueImageView m_view{};
-	vk::ImageLayout m_layout{};
 	std::uint32_t m_mip_levels{};
 };
 

--- a/lib/include/bave/graphics/detail/render_resource.hpp
+++ b/lib/include/bave/graphics/detail/render_resource.hpp
@@ -65,6 +65,7 @@ class RenderImage : public RenderResource {
 		vk::SampleCountFlagBits samples{vk::SampleCountFlagBits::e1};
 		vk::ImageViewType view_type{vk::ImageViewType::e2D};
 		bool mip_map{true};
+		bool lazily_allocated{false};
 	};
 
 	using Layer = std::span<std::byte const>;

--- a/lib/include/bave/graphics/detail/render_target.hpp
+++ b/lib/include/bave/graphics/detail/render_target.hpp
@@ -5,8 +5,8 @@ namespace bave::detail {
 enum class ColourSpace : int { eSrgb, eLinear };
 
 struct RenderTarget {
-	vk::Image image{};
-	vk::ImageView view{};
+	vk::ImageView swapchain{};
+	vk::ImageView msaa{};
 	vk::Extent2D extent{};
 	vk::Format format{};
 };

--- a/lib/include/bave/graphics/rect.hpp
+++ b/lib/include/bave/graphics/rect.hpp
@@ -84,4 +84,16 @@ using UvRect = Rect<float>;
 
 /// \brief Default UvRect (entire texture).
 inline constexpr UvRect uv_rect_v{.lt = {0.0f, 0.0f}, .rb = {1.0f, 1.0f}};
+
+/// \brief Convert a normalized point to UV coordinates.
+/// \param n_xy Normalized point in world space (origin at centre, +y goes up).
+/// \returns Point in UV space (origin at top-left, +y goes down).
+[[nodiscard]] constexpr auto to_uv_coords(glm::vec2 const n_xy) -> glm::vec2 { return glm::vec2{0.5f + n_xy.x, 0.5f - n_xy.y}; }
+
+/// \brief Convert a normalized Rect to UV coordinates.
+/// \param n_rect Normalized rect in world space (origin at centre, +y goes up).
+/// \returns Rect in UV space (origin at top-left, +y goes down).
+[[nodiscard]] constexpr auto to_uv_rect(Rect<> const& n_rect) -> UvRect {
+	return Rect<>{.lt = to_uv_coords(n_rect.top_left()), .rb = to_uv_coords(n_rect.bottom_right())};
+}
 } // namespace bave

--- a/lib/include/bave/graphics/render_device.hpp
+++ b/lib/include/bave/graphics/render_device.hpp
@@ -24,6 +24,7 @@ struct GLFWwindow;
 namespace bave {
 struct RenderDeviceCreateInfo {
 	detail::ColourSpace swapchain_colour_space{detail::ColourSpace::eSrgb};
+	vk::SampleCountFlagBits desired_samples{vk::SampleCountFlagBits::e1};
 	bool validation_layers{debug_v};
 };
 
@@ -50,6 +51,7 @@ class RenderDevice {
 	[[nodiscard]] auto get_swapchain_extent() const -> vk::Extent2D { return m_swapchain.create_info.imageExtent; }
 
 	[[nodiscard]] auto get_line_width_limits() const -> InclusiveRange<float> { return m_line_width_limits; }
+	[[nodiscard]] auto get_sample_count() const -> vk::SampleCountFlagBits { return m_samples; }
 	[[nodiscard]] auto get_frame_index() const -> detail::FrameIndex { return m_frame_index; }
 	[[nodiscard]] auto get_default_view() const -> RenderView;
 
@@ -106,6 +108,7 @@ class RenderDevice {
 	detail::DeviceBlocker m_blocker{};
 
 	InclusiveRange<float> m_line_width_limits{};
+	vk::SampleCountFlagBits m_samples{};
 	detail::FrameIndex m_frame_index{};
 };
 

--- a/lib/include/bave/graphics/render_view.hpp
+++ b/lib/include/bave/graphics/render_view.hpp
@@ -26,5 +26,14 @@ struct RenderView {
 	/// \param ndc Point in normalized device coordinates.
 	/// \returns Unprojected point in view space.
 	[[nodiscard]] auto unproject(glm::vec2 ndc) const -> glm::vec2;
+
+	/// \brief Convert a viewport Rect to normalized scissor (UV coordinates).
+	/// \param viewport_rect Rect in viewport space.
+	/// \returns Corresponding scissor rect.
+	[[nodiscard]] constexpr auto to_n_scissor(Rect<> viewport_rect) const -> Rect<> {
+		viewport_rect.lt /= viewport;
+		viewport_rect.rb /= viewport;
+		return to_uv_rect(viewport_rect);
+	}
 };
 } // namespace bave

--- a/lib/include/bave/graphics/renderer.hpp
+++ b/lib/include/bave/graphics/renderer.hpp
@@ -43,6 +43,7 @@ class Renderer : public Pinned {
 		};
 
 		detail::Buffered<Sync> syncs{};
+		std::optional<detail::RenderImage> msaa_image{};
 		vk::UniqueRenderPass render_pass{};
 
 		detail::Buffered<vk::UniqueFramebuffer> framebuffers{};

--- a/lib/include/bave/graphics/shader.hpp
+++ b/lib/include/bave/graphics/shader.hpp
@@ -24,6 +24,9 @@ class Shader {
 	auto write_ubo(void const* data, vk::DeviceSize size) -> bool;
 	auto write_ssbo(void const* data, vk::DeviceSize size) -> bool;
 
+	/// \brief Get the render view.
+	/// \returns The current render view.
+	[[nodiscard]] auto get_render_view() const -> RenderView;
 	/// \brief Set the render view.
 	/// \param render_view View to set.
 	void set_render_view(RenderView const& render_view);

--- a/lib/platform/android/android_app.cpp
+++ b/lib/platform/android/android_app.cpp
@@ -260,7 +260,7 @@ void AndroidApp::init_graphics() {
 		.desired_samples = m_msaa,
 		.validation_layers = m_validation_layers,
 	};
-	m_render_device = std::make_unique<RenderDevice>(this, rdci);
+	m_render_device = std::make_unique<RenderDevice>(static_cast<detail::IWsi*>(this), rdci);
 	m_renderer = std::make_unique<Renderer>(m_render_device.get(), &get_data_store());
 }
 

--- a/lib/platform/android/android_app.cpp
+++ b/lib/platform/android/android_app.cpp
@@ -217,6 +217,11 @@ auto AndroidApp::get_framebuffer_extent() const -> vk::Extent2D {
 	return {size.x, size.y};
 }
 
+void AndroidApp::do_wait_render_device_idle() {
+	if (!m_render_device) { return; }
+	m_render_device->get_device().waitIdle();
+}
+
 auto AndroidApp::self(Ptr<android_app> app) -> AndroidApp& {
 	auto* ret = static_cast<AndroidApp*>(app->userData);
 	if (ret == nullptr) { throw Error{"Dereferencing null GLFW Window User Pointer"}; }
@@ -285,7 +290,7 @@ void AndroidApp::start() {
 }
 
 void AndroidApp::destroy() {
-	get_render_device().get_device().waitIdle();
+	do_wait_render_device_idle();
 	m_driver.reset();
 	m_renderer.reset();
 	m_render_device.reset();

--- a/lib/platform/android/android_app.cpp
+++ b/lib/platform/android/android_app.cpp
@@ -146,7 +146,10 @@ auto find_index(Ptr<AInputEvent const> event, Pointer::Id id) -> std::optional<s
 }
 } // namespace
 
-AndroidApp::AndroidApp(android_app& app, bool validation_layers) : m_app(app), m_validation_layers(validation_layers) { m_app.userData = this; }
+AndroidApp::AndroidApp(android_app& app, vk::SampleCountFlagBits msaa, bool validation_layers)
+	: m_app(app), m_msaa(msaa), m_validation_layers(validation_layers) {
+	m_app.userData = this;
+}
 
 auto AndroidApp::setup() -> std::optional<ErrCode> {
 	app_dummy();
@@ -248,7 +251,11 @@ void AndroidApp::setup_event_callbacks() {
 }
 
 void AndroidApp::init_graphics() {
-	m_render_device = std::make_unique<RenderDevice>(this, RenderDevice::CreateInfo{.validation_layers = m_validation_layers});
+	auto const rdci = RenderDevice::CreateInfo{
+		.desired_samples = m_msaa,
+		.validation_layers = m_validation_layers,
+	};
+	m_render_device = std::make_unique<RenderDevice>(this, rdci);
 	m_renderer = std::make_unique<Renderer>(m_render_device.get(), &get_data_store());
 }
 

--- a/lib/platform/desktop/dear_imgui.cpp
+++ b/lib/platform/desktop/dear_imgui.cpp
@@ -60,7 +60,7 @@ DearImGui::DearImGui(Ptr<GLFWwindow> window, RenderDevice& render_device, vk::Re
 	init_info.Subpass = 0;
 	init_info.MinImageCount = 2;
 	init_info.ImageCount = 2;
-	init_info.MSAASamples = static_cast<VkSampleCountFlagBits>(vk::SampleCountFlagBits::e1);
+	init_info.MSAASamples = static_cast<VkSampleCountFlagBits>(render_device.get_sample_count());
 	init_info.ColorAttachmentFormat = static_cast<VkFormat>(render_device.get_swapchain_format());
 
 	ImGui_ImplVulkan_Init(&init_info, render_pass);

--- a/lib/platform/desktop/desktop_app.cpp
+++ b/lib/platform/desktop/desktop_app.cpp
@@ -332,7 +332,11 @@ void DesktopApp::make_window() {
 }
 
 void DesktopApp::init_graphics() {
-	m_render_device = std::make_unique<RenderDevice>(this, RenderDevice::CreateInfo{.validation_layers = m_create_info.validation_layers});
+	auto const rdci = RenderDevice::CreateInfo{
+		.desired_samples = m_create_info.msaa,
+		.validation_layers = m_create_info.validation_layers,
+	};
+	m_render_device = std::make_unique<RenderDevice>(this, rdci);
 	m_renderer = std::make_unique<Renderer>(m_render_device.get(), &get_data_store());
 	m_dear_imgui = std::make_unique<detail::DearImGui>(m_window.get(), *m_render_device, m_renderer->get_render_pass());
 }

--- a/lib/platform/desktop/desktop_app.cpp
+++ b/lib/platform/desktop/desktop_app.cpp
@@ -259,6 +259,11 @@ auto DesktopApp::do_set_window_icon(std::span<BitmapView const> bitmaps) -> bool
 	return true;
 }
 
+void DesktopApp::do_wait_render_device_idle() {
+	if (!m_render_device) { return; }
+	m_render_device->get_device().waitIdle();
+}
+
 auto DesktopApp::self(Ptr<GLFWwindow> window) -> DesktopApp& {
 	auto* ret = static_cast<DesktopApp*>(glfwGetWindowUserPointer(window));
 	if (ret == nullptr) { throw Error{"Dereferencing null GLFW Window User Pointer"}; }

--- a/lib/platform/desktop/desktop_app.cpp
+++ b/lib/platform/desktop/desktop_app.cpp
@@ -341,7 +341,7 @@ void DesktopApp::init_graphics() {
 		.desired_samples = m_create_info.msaa,
 		.validation_layers = m_create_info.validation_layers,
 	};
-	m_render_device = std::make_unique<RenderDevice>(this, rdci);
+	m_render_device = std::make_unique<RenderDevice>(static_cast<detail::IWsi*>(this), rdci);
 	m_renderer = std::make_unique<Renderer>(m_render_device.get(), &get_data_store());
 	m_dear_imgui = std::make_unique<detail::DearImGui>(m_window.get(), *m_render_device, m_renderer->get_render_pass());
 }

--- a/lib/src/app.cpp
+++ b/lib/src/app.cpp
@@ -42,7 +42,7 @@ auto App::run() -> ErrCode {
 			render();
 		}
 
-		get_render_device().get_device().waitIdle();
+		do_wait_render_device_idle();
 		return ErrCode::eSuccess;
 	} catch (std::exception const& e) {
 		m_log.error("FATAL: {}", e.what());

--- a/lib/src/graphics/detail/pipeline_cache.cpp
+++ b/lib/src/graphics/detail/pipeline_cache.cpp
@@ -49,7 +49,8 @@ PipelineCache::Key::Key(Program shader, State state)
 	: shader(shader), state(state), cached_hash(make_combined_hash(shader.vertex, shader.fragment, state.topology, state.polygon_mode)) {}
 
 PipelineCache::PipelineCache(vk::RenderPass render_pass, NotNull<RenderDevice*> render_device, NotNull<DataStore const*> data_store)
-	: m_shader_cache(render_device->get_device(), data_store), m_descriptor_cache(render_device), m_render_pass(render_pass) {
+	: m_shader_cache(render_device->get_device(), data_store), m_descriptor_cache(render_device), m_render_pass(render_pass),
+	  m_samples(render_device->get_sample_count()) {
 	auto pipeline_shader_layout = PipelineShaderLayout::make(render_device->get_device());
 
 	m_descriptor_set_layouts = std::move(pipeline_shader_layout).descriptor_set_layouts;
@@ -157,8 +158,8 @@ auto PipelineCache::build(Key const& key) -> vk::UniquePipeline {
 	gpci.pViewportState = &pvsci;
 
 	auto pmsci = vk::PipelineMultisampleStateCreateInfo{};
-	pmsci.rasterizationSamples = vk::SampleCountFlagBits::e1;
-	pmsci.sampleShadingEnable = 0;
+	pmsci.rasterizationSamples = m_samples;
+	pmsci.sampleShadingEnable = vk::False;
 	gpci.pMultisampleState = &pmsci;
 
 	gpci.renderPass = m_render_pass;

--- a/lib/src/graphics/detail/render_resource.cpp
+++ b/lib/src/graphics/detail/render_resource.cpp
@@ -286,30 +286,4 @@ auto RenderImage::overwrite(BitmapView const bitmap, glm::ivec2 top_left) -> boo
 
 	return true;
 }
-
-void RenderImage::resize(vk::Extent2D extent) {
-	assert(extent.width < 40960 && extent.height < 40960);
-	auto const mip_levels = m_create_info.mip_map ? compute_mip_levels(extent) : 1;
-	auto new_image = VmaImage::make(*m_render_device, m_create_info, extent, mip_levels);
-	auto const copy_src = CopyImage{
-		.image = m_image,
-		.layout = vk::ImageLayout::eShaderReadOnlyOptimal,
-		.extent = m_extent,
-	};
-	auto const copy_dst = CopyImage{
-		.image = new_image.image,
-		.layout = vk::ImageLayout::eUndefined,
-		.extent = extent,
-	};
-
-	auto cmd = detail::CommandBuffer{*m_render_device};
-	CopyImageToImage{
-		.source = copy_src,
-		.target = copy_dst,
-		.array_layers = m_create_info.view_type == vk::ImageViewType::eCube ? cubemap_layers_v : 1,
-		.mip_levels = mip_levels,
-	}(cmd);
-
-	cmd.submit(*m_render_device);
-}
 } // namespace bave::detail

--- a/lib/src/graphics/detail/render_resource.cpp
+++ b/lib/src/graphics/detail/render_resource.cpp
@@ -128,14 +128,14 @@ struct CopyBufferToImage {
 	std::uint32_t array_layers{1};
 	std::uint32_t mip_levels{1};
 
-	auto operator()(vk::CommandBuffer cmd) const {
+	auto operator()(vk::CommandBuffer const cmd, vk::ImageLayout const layout) const {
 		auto const isrl = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, array_layers);
 		auto const vk_extent = vk::Extent3D{source_extent, 1u};
 		auto const bic = vk::BufferImageCopy({}, {}, {}, isrl, vk::Offset3D{target_offset, 0}, vk_extent);
 		auto barrier = ImageBarrier{target_image, mip_levels, array_layers};
 		barrier.set_full_barrier(vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal).transition(cmd);
 		cmd.copyBufferToImage(source_bytes, target_image, vk::ImageLayout::eTransferDstOptimal, bic);
-		barrier.set_full_barrier(vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal).transition(cmd);
+		barrier.set_full_barrier(vk::ImageLayout::eTransferDstOptimal, layout).transition(cmd);
 
 		if (mip_levels > 1) { MipMapWriter{barrier, image_extent, cmd, mip_levels, array_layers}(); }
 	}
@@ -155,7 +155,7 @@ struct CopyImageToImage {
 	std::uint32_t array_layers{1};
 	std::uint32_t mip_levels{1};
 
-	auto operator()(vk::CommandBuffer cmd) const {
+	auto operator()(vk::CommandBuffer const cmd, vk::ImageLayout const layout) const {
 		auto const isrl = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, array_layers);
 		auto source_barrier = ImageBarrier{source.image, mip_levels, array_layers};
 		auto target_barrier = ImageBarrier{target.image, mip_levels, array_layers};
@@ -163,8 +163,8 @@ struct CopyImageToImage {
 		target_barrier.set_full_barrier(target.layout, vk::ImageLayout::eTransferDstOptimal).transition(cmd);
 		auto image_copy = vk::ImageCopy{isrl, vk::Offset3D{source.offset, 0}, isrl, vk::Offset3D{target.offset, 0}, vk::Extent3D{source.extent, 1}};
 		cmd.copyImage(source.image, vk::ImageLayout::eTransferSrcOptimal, target.image, vk::ImageLayout::eTransferDstOptimal, image_copy);
-		source_barrier.set_full_barrier(vk::ImageLayout::eTransferSrcOptimal, vk::ImageLayout::eShaderReadOnlyOptimal).transition(cmd);
-		target_barrier.set_full_barrier(vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal).transition(cmd);
+		source_barrier.set_full_barrier(vk::ImageLayout::eTransferSrcOptimal, layout).transition(cmd);
+		target_barrier.set_full_barrier(vk::ImageLayout::eTransferDstOptimal, layout).transition(cmd);
 
 		if (mip_levels > 1) { MipMapWriter{target_barrier, target.extent, cmd, mip_levels, array_layers}(); }
 	}
@@ -242,7 +242,7 @@ auto RenderImage::copy_from(BitmapView const bitmap) -> bool {
 		.source_extent = extent,
 		.array_layers = 1,
 		.mip_levels = m_mip_levels,
-	}(cmd.get());
+	}(cmd.get(), m_create_info.layout);
 
 	cmd.submit(*m_render_device);
 
@@ -250,7 +250,8 @@ auto RenderImage::copy_from(BitmapView const bitmap) -> bool {
 }
 
 void RenderImage::recreate(vk::Extent2D extent) {
-	if (extent.width == 0 || extent.height == 0 || extent == m_extent) { return; }
+	if (extent.width == 0 || extent.height == 0) { return; }
+	if (extent == m_extent) { return; }
 
 	auto const mip_levels = m_create_info.mip_map ? compute_mip_levels(extent) : 1;
 	auto vma_image = VmaImage::make(*m_render_device, m_create_info, extent, mip_levels);
@@ -258,12 +259,11 @@ void RenderImage::recreate(vk::Extent2D extent) {
 	m_image = {vma_image.image, Deleter{.allocator = m_render_device->get_allocator(), .allocation = vma_image.allocation}};
 	m_view = std::move(vma_image.image_view);
 	m_extent = extent;
-	m_layout = vk::ImageLayout::eUndefined;
 	m_mip_levels = mip_levels;
 
 	auto cmd = detail::CommandBuffer{*m_render_device};
 	auto barrier = ImageBarrier{m_image, mip_levels, 1};
-	barrier.set_full_barrier(vk::ImageLayout::eUndefined, vk::ImageLayout::eShaderReadOnlyOptimal).transition(cmd);
+	barrier.set_full_barrier(vk::ImageLayout::eUndefined, m_create_info.layout).transition(cmd);
 	cmd.submit(*m_render_device);
 }
 
@@ -287,7 +287,7 @@ auto RenderImage::overwrite(BitmapView const bitmap, glm::ivec2 top_left) -> boo
 		.source_extent = to_vk_extent(bitmap.extent),
 		.array_layers = 1,
 		.mip_levels = m_mip_levels,
-	}(cmd.get());
+	}(cmd.get(), m_create_info.layout);
 
 	cmd.submit(*m_render_device);
 

--- a/lib/src/graphics/render_device.cpp
+++ b/lib/src/graphics/render_device.cpp
@@ -42,6 +42,18 @@ constexpr auto composite_alpha(vk::SurfaceCapabilitiesKHR const& caps) -> vk::Co
 	// according to the spec, at least one bit must be set
 	return vk::CompositeAlphaFlagBitsKHR::ePostMultiplied;
 }
+
+constexpr auto sample_count(vk::SampleCountFlags const supported, vk::SampleCountFlagBits const desired) {
+	if (supported & desired) { return desired; }
+	constexpr auto values_v = std::array{
+		vk::SampleCountFlagBits::e64, vk::SampleCountFlagBits::e32, vk::SampleCountFlagBits::e16,
+		vk::SampleCountFlagBits::e8,  vk::SampleCountFlagBits::e4,	vk::SampleCountFlagBits::e2,
+	};
+	for (auto const value : values_v) {
+		if (desired >= value && (supported & value)) { return value; }
+	}
+	return vk::SampleCountFlagBits::e1;
+}
 } // namespace
 
 RenderDevice::RenderDevice(NotNull<detail::IWsi*> wsi, CreateInfo create_info) : m_wsi(wsi) {
@@ -59,6 +71,7 @@ RenderDevice::RenderDevice(NotNull<detail::IWsi*> wsi, CreateInfo create_info) :
 
 	auto device_builder = detail::DeviceBuilder{*m_instance, *m_surface};
 	m_gpu = m_wsi->select_gpu(device_builder.get_gpus());
+	m_samples = sample_count(m_gpu.device.getProperties().limits.sampledImageColorSampleCounts, create_info.desired_samples);
 
 	auto device = device_builder.build();
 	if (!device.device) { throw Error{"Failed to create Vulkan Device"}; }
@@ -82,6 +95,8 @@ RenderDevice::RenderDevice(NotNull<detail::IWsi*> wsi, CreateInfo create_info) :
 	m_line_width_limits = {line_width_range[0], line_width_range[1]};
 
 	render_view = get_default_view();
+
+	m_log.info("using MSAA: {}x", static_cast<int>(m_samples));
 }
 
 auto RenderDevice::get_default_view() const -> RenderView {
@@ -218,8 +233,7 @@ auto RenderDevice::recreate_swapchain(vk::Extent2D framebuffer) -> bool {
 	for (auto const image : images) {
 		m_swapchain.active.views.push_back(detail::MakeImageView{.image = image, .format = m_swapchain.create_info.imageFormat}(get_device()));
 		m_swapchain.active.render_targets.push_back({
-			.image = image,
-			.view = *m_swapchain.active.views.back(),
+			.swapchain = *m_swapchain.active.views.back(),
 			.extent = m_swapchain.create_info.imageExtent,
 			.format = m_swapchain.create_info.imageFormat,
 		});

--- a/lib/src/graphics/render_device.cpp
+++ b/lib/src/graphics/render_device.cpp
@@ -36,23 +36,24 @@ constexpr auto image_extent(vk::SurfaceCapabilitiesKHR const& caps, vk::Extent2D
 }
 
 constexpr auto composite_alpha(vk::SurfaceCapabilitiesKHR const& caps) -> vk::CompositeAlphaFlagBitsKHR {
-	if (caps.supportedCompositeAlpha & vk::CompositeAlphaFlagBitsKHR::eOpaque) { return vk::CompositeAlphaFlagBitsKHR::eOpaque; }
-	if (caps.supportedCompositeAlpha & vk::CompositeAlphaFlagBitsKHR::eInherit) { return vk::CompositeAlphaFlagBitsKHR::eInherit; }
-	if (caps.supportedCompositeAlpha & vk::CompositeAlphaFlagBitsKHR::ePreMultiplied) { return vk::CompositeAlphaFlagBitsKHR::ePreMultiplied; }
+	using enum vk::CompositeAlphaFlagBitsKHR;
+	if (caps.supportedCompositeAlpha & eOpaque) { return eOpaque; }
+	if (caps.supportedCompositeAlpha & eInherit) { return eInherit; }
+	if (caps.supportedCompositeAlpha & ePreMultiplied) { return ePreMultiplied; }
 	// according to the spec, at least one bit must be set
-	return vk::CompositeAlphaFlagBitsKHR::ePostMultiplied;
+	return ePostMultiplied;
 }
 
 constexpr auto sample_count(vk::SampleCountFlags const supported, vk::SampleCountFlagBits const desired) {
 	if (supported & desired) { return desired; }
+	using enum vk::SampleCountFlagBits;
 	constexpr auto values_v = std::array{
-		vk::SampleCountFlagBits::e64, vk::SampleCountFlagBits::e32, vk::SampleCountFlagBits::e16,
-		vk::SampleCountFlagBits::e8,  vk::SampleCountFlagBits::e4,	vk::SampleCountFlagBits::e2,
+		e64, e32, e16, e8, e4, e2,
 	};
 	for (auto const value : values_v) {
 		if (desired >= value && (supported & value)) { return value; }
 	}
-	return vk::SampleCountFlagBits::e1;
+	return e1;
 }
 } // namespace
 

--- a/lib/src/graphics/renderer.cpp
+++ b/lib/src/graphics/renderer.cpp
@@ -95,10 +95,11 @@ auto Renderer::Frame::make(RenderDevice& render_device) -> Frame {
 	if (render_device.get_sample_count() > vk::SampleCountFlagBits::e1) {
 		auto const ici = detail::RenderImage::CreateInfo{
 			.format = render_device.get_swapchain_format(),
-			.usage = detail::RenderImage::CreateInfo::usage_v | vk::ImageUsageFlagBits::eColorAttachment,
+			.usage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransientAttachment,
 			.aspect = vk::ImageAspectFlagBits::eColor,
 			.samples = render_device.get_sample_count(),
 			.mip_map = false,
+			.lazily_allocated = true,
 		};
 		ret.msaa_image.emplace(&render_device, ici);
 	}

--- a/lib/src/graphics/renderer.cpp
+++ b/lib/src/graphics/renderer.cpp
@@ -97,6 +97,7 @@ auto Renderer::Frame::make(RenderDevice& render_device) -> Frame {
 			.format = render_device.get_swapchain_format(),
 			.usage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransientAttachment,
 			.aspect = vk::ImageAspectFlagBits::eColor,
+			.layout = vk::ImageLayout::eColorAttachmentOptimal,
 			.samples = render_device.get_sample_count(),
 			.mip_map = false,
 			.lazily_allocated = true,

--- a/lib/src/graphics/shader.cpp
+++ b/lib/src/graphics/shader.cpp
@@ -159,6 +159,8 @@ auto Shader::write_ssbo(void const* data, vk::DeviceSize const size) -> bool {
 	return true;
 }
 
+auto Shader::get_render_view() const -> RenderView { return m_renderer->get_render_device().render_view; }
+
 void Shader::set_render_view(RenderView const& render_view) { m_renderer->get_render_device().render_view = render_view; }
 
 void Shader::draw(RenderPrimitive const& primitive, std::span<RenderInstance::Baked const> instances) {


### PR DESCRIPTION
- Add `to_uv_rect()` and `RenderView::to_n_scissor()`.
- Add MSAA (multi sampled anti aliasing) support.
- Use lazily allocated (memoryless) MSAA image if available.
- Fix potential overflow in the general constructor of `FixedString`.
- Make `DesktopApp` and `AndroidApp` inherit privately from `App`. This tightens the API available to either platform's main: they can only call `App::set_bootloader()` and `App::run()`.

