### PR TITLE
v0.4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(project_prefix bave)
-project(${project_prefix} VERSION 0.4.3)
+project(${project_prefix} VERSION 0.4.4)
 
 set(is_root_project FALSE)
 

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -1,12 +1,12 @@
 # Changelog
 
-### v-next
+## v0.4
+
+### v0.4.4
 
 - Added bave::App::update_gamepad_mappings() for custom GLFW gamepad mappings.
 - Inverted GLFW gamepad left and right axis Y values.
 - Add `dead_zone` argument to bave::Gamepad::get_axis().
-
-## v0.4
 
 ### v0.4.3
 

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v-next
+
+- Added bave::App::update_gamepad_mappings() for custom GLFW gamepad mappings.
+- Inverted GLFW gamepad left and right axis Y values.
+- Add `dead_zone` argument to bave::Gamepad::get_axis().
+
 ## v0.4
 
 ### v0.4.3

--- a/lib/docs/changelog.md
+++ b/lib/docs/changelog.md
@@ -6,7 +6,7 @@
 
 - Added bave::App::update_gamepad_mappings() for custom GLFW gamepad mappings.
 - Inverted GLFW gamepad left and right axis Y values.
-- Add `dead_zone` argument to bave::Gamepad::get_axis().
+- Added `dead_zone` argument to bave::Gamepad::get_axis().
 
 ### v0.4.3
 

--- a/lib/include/bave/app.hpp
+++ b/lib/include/bave/app.hpp
@@ -118,6 +118,10 @@ class App : public PolyPinned {
 	/// Currently gamepads are only processed on desktop.
 	[[nodiscard]] auto get_most_recent_gamepad() const -> Gamepad const& { return get_gamepad(m_most_recent_gamepad); }
 
+	/// \brief Update GLFW gamepad mappings.
+	/// \param text contents in SDL game controller DB format.
+	void update_gamepad_mappings(CString const text) { do_update_gamepad_mappings(text); }
+
 	[[nodiscard]] auto get_features() const -> FeatureFlags;
 
 	/// \brief Wait until RenderDevice is idle.
@@ -181,6 +185,7 @@ class App : public PolyPinned {
 	virtual auto do_set_window_size(glm::ivec2 size) -> bool = 0;
 	virtual auto do_set_title(CString /*title*/) -> bool { return false; }
 	virtual auto do_set_window_icon(std::span<BitmapView const> /*bitmaps*/) -> bool { return false; }
+	virtual void do_update_gamepad_mappings(CString /*text*/) {}
 
 	virtual void do_wait_render_device_idle() = 0;
 

--- a/lib/include/bave/desktop_app.hpp
+++ b/lib/include/bave/desktop_app.hpp
@@ -93,6 +93,7 @@ class DesktopApp : private App, private detail::IWsi {
 	auto do_set_window_size(glm::ivec2 size) -> bool final;
 	auto do_set_title(CString title) -> bool final;
 	auto do_set_window_icon(std::span<BitmapView const> bitmaps) -> bool final;
+	void do_update_gamepad_mappings(CString text) final;
 
 	void do_wait_render_device_idle() final;
 

--- a/lib/include/bave/input/gamepad.hpp
+++ b/lib/include/bave/input/gamepad.hpp
@@ -85,6 +85,10 @@ struct Gamepad {
 	///
 	/// eLeftTrigger and eRightTrigger have a range of [0, 1].
 	/// All other axes have a range of [-1, 1].
-	[[nodiscard]] auto get_axis(Axis const axis) const -> float { return axes.at(axis); }
+	[[nodiscard]] auto get_axis(Axis const axis, float const dead_zone = 0.05f) const -> float {
+		auto const ret = axes.at(axis);
+		if (std::abs(ret) < dead_zone) { return 0.0f; }
+		return ret;
+	}
 };
 } // namespace bave

--- a/lib/platform/desktop/desktop_app.cpp
+++ b/lib/platform/desktop/desktop_app.cpp
@@ -364,8 +364,11 @@ void DesktopApp::update_gamepads() {
 		std::memcpy(gamepad.axes.data(), axes.data(), axes.size_bytes());
 		// adjust triggers to be in [0, 1], otherwise the rest value is -1.
 		static constexpr auto project_trigger = [](float& out) { out = (out + 1.0f) * 0.5f; };
+		static constexpr auto invert_axis = [](float& out) { out = -out; };
 		project_trigger(gamepad.axes.at(GamepadAxis::eLeftTrigger));
 		project_trigger(gamepad.axes.at(GamepadAxis::eRightTrigger));
+		invert_axis(gamepad.axes.at(GamepadAxis::eLeftY));
+		invert_axis(gamepad.axes.at(GamepadAxis::eRightY));
 		gamepad.button_states = {};
 		for (std::size_t b = 0; b < buttons.size(); ++b) {
 			if (buttons[b] == 0x1) { gamepad.button_states.set(static_cast<GamepadButton>(b)); }

--- a/lib/platform/desktop/desktop_app.cpp
+++ b/lib/platform/desktop/desktop_app.cpp
@@ -259,6 +259,8 @@ auto DesktopApp::do_set_window_icon(std::span<BitmapView const> bitmaps) -> bool
 	return true;
 }
 
+void DesktopApp::do_update_gamepad_mappings(CString text) { glfwUpdateGamepadMappings(text.c_str()); }
+
 void DesktopApp::do_wait_render_device_idle() {
 	if (!m_render_device) { return; }
 	m_render_device->get_device().waitIdle();


### PR DESCRIPTION
- Add `App::update_gamepad_mappings()` for custom GLFW gamepad mappings.
- Invert GLFW gamepad left and right axis Y values.
- Add `dead_zone` argument to `Gamepad::get_axis()`.
